### PR TITLE
Feature: Don't break on forked PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Permissively handle missing credentials for forked PRs for staging actions.
+* Harmonize `deploy --production|staging` logic and messages.
+
 ## 0.2.0
 
 * BREAKING: Refactor configuration shape minorly.

--- a/lib/actions/deploy/production.js
+++ b/lib/actions/deploy/production.js
@@ -40,6 +40,15 @@ const s3Path = (extra = "") => `s3://${path.join(bucket, basePath, extra)}`;
 // `path/to/dir` -> `path/to/dir/index.hml`
 const redirectFile = (f) => path.extname(f) ? f : path.join(f, "index.html");
 
+const isAuthenticated = () => exec({
+  cmd: "aws",
+  args: ["sts", "get-caller-identity"],
+  opts: { stdio: "pipe" },
+  log
+})
+  .then(() => true)
+  .catch(() => false);
+
 // Publish to AWS with redirects, CDN, etc.
 // eslint-disable-next-line max-statements
 const awsPublish = async ({ dryrun, url }) => {
@@ -205,12 +214,19 @@ const production = async ({ dryrun }) => {
   const deployment = new Deployment({ environment: "production", url, dryrun, log, error });
   await deployment.start();
 
-  // Publish.
-  const err = await awsPublish({ dryrun, url }).catch((e) => e);
+  // Check if authenticated.
+  let err;
+  let state = "skipped";
+  let msg = chalk.yellow(state);
+  if (await isAuthenticated()) {
+    // Publish.
+    err = await awsPublish({ dryrun, url }).catch((e) => e);
+    state = err ? "failure" : "success";
+    msg = chalk[err ? "red" : "green"](state);
+  }
 
   // Logging, notifications
-  const state = err ? "failure" : "success";
-  log(chalk `Publish {${err ? "red" : "green"} ${state}} for: {cyan.underline ${url}}`);
+  log(chalk `Publish ${msg} for: {cyan.underline ${url}}`);
   await deployment.finish({ state });
 
   // Bail on error.

--- a/lib/actions/deploy/staging.js
+++ b/lib/actions/deploy/staging.js
@@ -17,12 +17,14 @@ const { Deployment } = require("../../github/deployment");
 
 const { log, error } = getLoggers("deploy:staging");
 
-const surgeCheckAuthenticated = async () => {
+const isAuthenticated = async () => {
   log("Checking authentication status");
   const { stdout } = await execa(SURGE_PATH, ["whoami"]);
   if (!stdout || stdout.includes("Not Authenticated")) {
-    throw new Error("Environment is missing surge credentials");
+    return false;
   }
+
+  return true;
 };
 
 const surgePublish = async ({ dryrun, url }) => {
@@ -38,14 +40,12 @@ const surgePublish = async ({ dryrun, url }) => {
     return void log(chalk `{yellow Skipping deployment} (dryrun): {gray ${[cmd, ...args].join(" ")}}`);
   }
 
-  // Check authentication.
-  await surgeCheckAuthenticated();
-
   // Publish.
   log(chalk `Publishing build from "{cyan ${build.path}}" to staging: {cyan.underline ${url}}`);
   await exec({ cmd, args, log });
 };
 
+// eslint-disable-next-line max-statements
 const staging = async ({ dryrun }) => {
   await validate(config);
 
@@ -63,12 +63,19 @@ const staging = async ({ dryrun }) => {
   });
   await deployment.start();
 
-  // Publish.
-  const err = await surgePublish({ dryrun, url }).catch((e) => e);
+  // Check if authenticated.
+  let err;
+  let state = "skipped";
+  let msg = chalk.yellow(state);
+  if (await isAuthenticated()) {
+    // Publish.
+    err = await surgePublish({ dryrun, url }).catch((e) => e);
+    state = err ? "failure" : "success";
+    msg = chalk[err ? "red" : "green"](state);
+  }
 
   // Logging, notifications
-  const state = err ? "failure" : "success";
-  log(chalk `Publish {${err ? "red" : "green"} ${state}} for: {cyan.underline ${url}}`);
+  log(chalk `Publish ${msg} for: {cyan.underline ${url}}`);
   await deployment.finish({ state });
 
   // Bail on error.


### PR DESCRIPTION
* Permissively handle missing credentials for forked PRs for staging actions.
* Harmonize `deploy --production|staging` logic and messages.