### PR TITLE
chore: increase cache timeout for media

### DIFF
--- a/lib/actions/deploy/production.js
+++ b/lib/actions/deploy/production.js
@@ -89,7 +89,7 @@ const publishFiles = async (filePaths, cacheMaxAge, dryrunFlag) => {
       "--cache-control",
       `max-age=${cacheMaxAge},public`,
       "--exclude",
-      "*",
+      "\"*\"",
       ...includes,
       s3Dest,
       s3Dest

--- a/lib/actions/deploy/production.js
+++ b/lib/actions/deploy/production.js
@@ -41,11 +41,18 @@ const AWS_EXCLUDES = ["*.DS_Store*"];
 // hashed based on _source_ but not _actually produced_ contents.
 const HASHED_FILE_RE = /[/.][a-f0-9]{8,}\.[a-z]+$/;
 
+const MEDIA_FILE_TYPES = ["bmp", "gif", "jpg", "jpeg", "png", "svg", "webp"];
+const isMediaType = (file) => {
+  const ext = path.extname(file).slice(1);
+  return MEDIA_FILE_TYPES.includes(ext);
+};
+
 // Cache values (in seconds)
 // TODO(15): Implement better caching.
 // https://github.com/FormidableLabs/formideploy/issues/15
 const CACHE_MAX_AGE_DEFAULT = 10 * 60; // eslint-disable-line no-magic-numbers
 const CACHE_MAX_AGE_HASHED = 365 * 24 * 60 * 60; // eslint-disable-line no-magic-numbers
+const CACHE_MAX_AGE_MEDIA = 24 * 60 * 60; // eslint-disable-line no-magic-numbers
 
 const s3Path = (extra = "") => `s3://${path.join(bucket, basePath, extra)}`;
 
@@ -68,6 +75,32 @@ const isAuthenticated = () => execAws({
     log(chalk `AWS authentication failure reason: {gray ${stderr.trim()}}`);
     return false;
   });
+
+// Upload an array of files to s3
+const publishFiles = async (filePaths, cacheMaxAge, dryrunFlag) => {
+  const s3Dest = s3Path();
+  const includes = filePaths
+    .map((f) => ["--include", f])
+    .reduce((m, a) => m.concat(a), []);
+  await execAws({
+    args: [
+      "s3",
+      "cp",
+      dryrunFlag,
+      "--recursive",
+      "--copy-props",
+      "metadata-directive",
+      "--cache-control",
+      `max-age=${cacheMaxAge},public`,
+      "--exclude",
+      "*",
+      ...includes,
+      s3Dest,
+      s3Dest
+    ].filter(Boolean),
+    log
+  });
+};
 
 // Publish to AWS with redirects, CDN, etc.
 // eslint-disable-next-line max-statements
@@ -120,30 +153,19 @@ const awsPublish = async ({ dryrun, url, archiveInfo }) => {
   //
   // Do a "fake" copy within the bucket to force metadata updates.
   const files = await getFiles({ dir: srcPath });
-  const hashedPaths = files.filter((f) => HASHED_FILE_RE.test(f));
-  const hashedIncludes = hashedPaths
-    .map((f) => ["--include", path.relative(srcPath, f)])
-    .reduce((m, a) => m.concat(a), []);
+  const hashedPaths = files
+    .filter((f) => HASHED_FILE_RE.test(f))
+    .map((f) => path.relative(srcPath, f));
 
   log(chalk `Setting longer TTLs on {cyan ${hashedPaths.length}} hashed assets`);
-  await execAws({
-    args: [
-      "s3",
-      "cp",
-      dryrunFlag,
-      "--recursive",
-      "--copy-props",
-      "metadata-directive",
-      "--cache-control",
-      `max-age=${CACHE_MAX_AGE_HASHED},public`,
-      "--exclude",
-      "*",
-      ...hashedIncludes,
-      s3Dest,
-      s3Dest
-    ].filter(Boolean),
-    log
-  });
+  await publishFiles(hashedPaths, CACHE_MAX_AGE_HASHED, dryrunFlag);
+
+  const mediaPaths = files
+    .filter(isMediaType)
+    .map((f) => path.relative(srcPath, f));
+
+  log(chalk `Setting longer TTLs on {cyan ${mediaPaths.length}} media assets`);
+  await publishFiles(mediaPaths, CACHE_MAX_AGE_MEDIA, dryrunFlag);
 
   // Create redirects.
   //

--- a/lib/actions/deploy/production.js
+++ b/lib/actions/deploy/production.js
@@ -154,11 +154,12 @@ const awsPublish = async ({ dryrun, url, archiveInfo }) => {
     .filter((f) => HASHED_FILE_RE.test(f))
     .map((f) => path.relative(srcPath, f));
 
+  log(chalk `Setting longer TTLs on all media assets`);
+  await publishFiles(MEDIA_FILE_TYPES.map((f) => `"*.${f}"`), CACHE_MAX_AGE_MEDIA, dryrun);
+
   log(chalk `Setting longer TTLs on {cyan ${hashedPaths.length}} hashed assets`);
   await publishFiles(hashedPaths, CACHE_MAX_AGE_HASHED, dryrun);
 
-  log(chalk `Setting longer TTLs on all media assets`);
-  await publishFiles(MEDIA_FILE_TYPES.map((f) => `"*.${f}"`), CACHE_MAX_AGE_MEDIA, dryrun);
 
   // Create redirects.
   //

--- a/lib/actions/deploy/production.js
+++ b/lib/actions/deploy/production.js
@@ -42,10 +42,6 @@ const AWS_EXCLUDES = ["*.DS_Store*"];
 const HASHED_FILE_RE = /[/.][a-f0-9]{8,}\.[a-z]+$/;
 
 const MEDIA_FILE_TYPES = ["bmp", "gif", "jpg", "jpeg", "png", "svg", "webp"];
-const isMediaType = (file) => {
-  const ext = path.extname(file).slice(1);
-  return MEDIA_FILE_TYPES.includes(ext);
-};
 
 // Cache values (in seconds)
 // TODO(15): Implement better caching.
@@ -160,12 +156,8 @@ const awsPublish = async ({ dryrun, url, archiveInfo }) => {
   log(chalk `Setting longer TTLs on {cyan ${hashedPaths.length}} hashed assets`);
   await publishFiles(hashedPaths, CACHE_MAX_AGE_HASHED, dryrunFlag);
 
-  const mediaPaths = files
-    .filter(isMediaType)
-    .map((f) => path.relative(srcPath, f));
-
-  log(chalk `Setting longer TTLs on {cyan ${mediaPaths.length}} media assets`);
-  await publishFiles(mediaPaths, CACHE_MAX_AGE_MEDIA, dryrunFlag);
+  log(chalk `Setting longer TTLs on all media assets`);
+  await publishFiles(MEDIA_FILE_TYPES.map((f) => `"*.${f}"`), CACHE_MAX_AGE_MEDIA, dryrunFlag);
 
   // Create redirects.
   //

--- a/lib/actions/deploy/production.js
+++ b/lib/actions/deploy/production.js
@@ -73,7 +73,8 @@ const isAuthenticated = () => execAws({
   });
 
 // Upload an array of files to s3
-const publishFiles = async (filePaths, cacheMaxAge, dryrunFlag) => {
+const publishFiles = async (filePaths, cacheMaxAge, dryrun) => {
+  const dryrunFlag = dryrun ? AWS_DRY_RUN_FLAG : "";
   const s3Dest = s3Path();
   const includes = filePaths
     .map((f) => ["--include", f])
@@ -154,10 +155,10 @@ const awsPublish = async ({ dryrun, url, archiveInfo }) => {
     .map((f) => path.relative(srcPath, f));
 
   log(chalk `Setting longer TTLs on {cyan ${hashedPaths.length}} hashed assets`);
-  await publishFiles(hashedPaths, CACHE_MAX_AGE_HASHED, dryrunFlag);
+  await publishFiles(hashedPaths, CACHE_MAX_AGE_HASHED, dryrun);
 
   log(chalk `Setting longer TTLs on all media assets`);
-  await publishFiles(MEDIA_FILE_TYPES.map((f) => `"*.${f}"`), CACHE_MAX_AGE_MEDIA, dryrunFlag);
+  await publishFiles(MEDIA_FILE_TYPES.map((f) => `"*.${f}"`), CACHE_MAX_AGE_MEDIA, dryrun);
 
   // Create redirects.
   //


### PR DESCRIPTION
Media doesn't change too often so 10 minutes isn't enough time and it's impacting lighthouse scores. This attempts to increase the default cache time for media. 